### PR TITLE
feat: connect feedback api, handle fetch errors, edit feedback card, edit mobile screen width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/app/(main)/(home)/(search)/_components/history/HistoryCards.tsx
+++ b/app/(main)/(home)/(search)/_components/history/HistoryCards.tsx
@@ -5,6 +5,8 @@ import { useResultStore } from '@/lib/store';
 import { YoutubeInfo } from '@/lib/types';
 import { useEffect, useState } from 'react';
 import NavigatorHeader from '../NavigatorHeader';
+import { cn } from '@/lib/utils';
+import CardComponent from '@/components/CardComponent';
 
 const HistoryCards = () => {
   const results = useResultStore((state) => state.results);
@@ -29,11 +31,16 @@ const HistoryCards = () => {
           <NavigatorHeader location='/history' linkText='전체 보기'>
             <p className='pl-4 font-extrabold text-primary'>검색 기록</p>
           </NavigatorHeader>
-          <div className='flex h-max min-h-24 w-96 cursor-pointer items-center justify-around rounded-3xl bg-white p-4 shadow-md mobile:w-full mobile:gap-2'>
+          <CardComponent
+            className={cn(
+              'flex-row items-center mobile:gap-2 mobile:p-6',
+              histories.length === 1 ? 'justify-start' : 'justify-around'
+            )}
+          >
             {histories.map((history, index) => (
               <HistoryCard {...history} key={index} />
             ))}
-          </div>
+          </CardComponent>
         </div>
       )}
     </>

--- a/app/(main)/(home)/(search)/_components/input/LinkCard.tsx
+++ b/app/(main)/(home)/(search)/_components/input/LinkCard.tsx
@@ -15,6 +15,7 @@ import { forwardRef } from 'react';
 import { useLoadingStore } from '@/lib/LoadingStore';
 import { fetchAnalyze } from '../../_utils/fetchAnalyze';
 import { analyzeSchema } from '../../_utils/analyzeSchema';
+import { useToast } from '@/components/ui/use-toast';
 
 const LinkComponent = forwardRef(
   (
@@ -28,6 +29,8 @@ const LinkComponent = forwardRef(
     const { addResult } = useResultStore();
     const setLoading = useLoadingStore((state) => state.setLoading);
 
+    const { toast } = useToast();
+
     const form = useForm<z.infer<typeof analyzeSchema>>({
       resolver: zodResolver(analyzeSchema),
       defaultValues: { url: '' },
@@ -35,7 +38,7 @@ const LinkComponent = forwardRef(
 
     const onSubmit = async (data: z.infer<typeof analyzeSchema>) => {
       setLoading(Loading.start);
-      await fetchAnalyze(data.url, addResult);
+      await fetchAnalyze(data.url, addResult, toast, setLoading);
     };
 
     return (

--- a/app/(main)/(home)/(search)/_components/input/LinkCard.tsx
+++ b/app/(main)/(home)/(search)/_components/input/LinkCard.tsx
@@ -13,6 +13,7 @@ import NavigatorHeader from '../NavigatorHeader';
 import MainInput from './MainInput';
 import { forwardRef } from 'react';
 import { useLoadingStore } from '@/lib/LoadingStore';
+import { useToast } from '@/components/ui/use-toast';
 
 const youtubeUrlPattern = /^(https?:\/\/)?(www\.)?(youtu\.be|youtube\.com)/;
 
@@ -21,23 +22,6 @@ const formSchema = z.object({
     message: '유효한 유튜브 링크를 입력해주세요.',
   }),
 });
-
-// TODO: 추후 Flask 서버로부터의 페칭으로 수정
-const fetchData = async (
-  url: string,
-  addResult: (video_id: string, result: ResultData) => void
-) => {
-  const res = await fetch('api/analyze', {
-    method: 'POST',
-    body: JSON.stringify({ url }),
-  });
-  const result: ResultData = await res.json();
-  addResult(result.youtube_info.video_id, result);
-  // 데이터 페칭이 6초 ~ 15초 사이 랜덤하게 걸린다고 가정
-  await new Promise((resolve) =>
-    setTimeout(resolve, Math.random() * 9000 + 6000)
-  );
-};
 
 const LinkComponent = forwardRef(
   (
@@ -51,15 +35,47 @@ const LinkComponent = forwardRef(
     const { addResult } = useResultStore();
     const setLoading = useLoadingStore((state) => state.setLoading);
 
+    const { toast } = useToast();
+
     const form = useForm<z.infer<typeof formSchema>>({
       resolver: zodResolver(formSchema),
       defaultValues: { url: '' },
     });
 
+    // TODO: 추후 Flask 서버로부터의 페칭으로 수정, Promise 제거
+    const fetchData = async (
+      url: string,
+      addResult: (video_id: string, result: ResultData) => void
+    ) => {
+      try {
+        const res = await fetch('api/analyze', {
+          method: 'POST',
+          body: JSON.stringify({ url }),
+        });
+        // 데이터 페칭이 6초 ~ 15초 사이 랜덤하게 걸린다고 가정
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.random() * 9000 + 6000)
+        );
+        if (!res.ok) {
+          throw new Error('서버에서 오류가 발생했습니다.');
+        } else {
+          const result: ResultData = await res.json();
+          addResult(result.youtube_info.video_id, result);
+          setLoading(Loading.done);
+        }
+      } catch (error) {
+        setLoading(Loading.before);
+        toast({
+          title: '영상 분석 실패',
+          description: '잠시 후 다시 시도해주세요.',
+          variant: 'destructive',
+        });
+      }
+    };
+
     const onSubmit = async (data: z.infer<typeof formSchema>) => {
       setLoading(Loading.start);
       await fetchData(data.url, addResult);
-      setLoading(Loading.done);
     };
 
     return (

--- a/app/(main)/(home)/(search)/_utils/analyzeSchema.ts
+++ b/app/(main)/(home)/(search)/_utils/analyzeSchema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const youtubeUrlPattern = /^(https?:\/\/)?(www\.)?(youtu\.be|youtube\.com)/;
+
+export const analyzeSchema = z.object({
+  url: z.string().regex(youtubeUrlPattern, {
+    message: '유효한 유튜브 링크를 입력해주세요.',
+  }),
+});

--- a/app/(main)/(home)/(search)/_utils/fetchAnalyze.ts
+++ b/app/(main)/(home)/(search)/_utils/fetchAnalyze.ts
@@ -1,14 +1,12 @@
-import { useToast } from '@/components/ui/use-toast';
-import { useLoadingStore } from '@/lib/LoadingStore';
 import { Loading, ResultData } from '@/lib/types';
 
 // TODO: 추후 Flask 서버로부터의 페칭으로 수정, Promise 제거
 export const fetchAnalyze = async (
   url: string,
-  addResult: (video_id: string, result: ResultData) => void
+  addResult: (video_id: string, result: ResultData) => void,
+  toast: any,
+  setLoading: (loading: Loading) => void
 ) => {
-  const { toast } = useToast();
-  const setLoading = useLoadingStore((state) => state.setLoading);
   try {
     const res = await fetch('api/analyze', {
       method: 'POST',

--- a/app/(main)/(home)/(search)/_utils/fetchAnalyze.ts
+++ b/app/(main)/(home)/(search)/_utils/fetchAnalyze.ts
@@ -1,0 +1,36 @@
+import { useToast } from '@/components/ui/use-toast';
+import { useLoadingStore } from '@/lib/LoadingStore';
+import { Loading, ResultData } from '@/lib/types';
+
+// TODO: 추후 Flask 서버로부터의 페칭으로 수정, Promise 제거
+export const fetchAnalyze = async (
+  url: string,
+  addResult: (video_id: string, result: ResultData) => void
+) => {
+  const { toast } = useToast();
+  const setLoading = useLoadingStore((state) => state.setLoading);
+  try {
+    const res = await fetch('api/analyze', {
+      method: 'POST',
+      body: JSON.stringify({ url }),
+    });
+    // 데이터 페칭이 6초 ~ 15초 사이 랜덤하게 걸린다고 가정
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.random() * 9000 + 6000)
+    );
+    if (!res.ok) {
+      throw new Error('서버에서 오류가 발생했습니다.');
+    } else {
+      const result: ResultData = await res.json();
+      addResult(result.youtube_info.video_id, result);
+      setLoading(Loading.done);
+    }
+  } catch (error) {
+    setLoading(Loading.before);
+    toast({
+      title: '영상 분석 실패',
+      description: '잠시 후 다시 시도해주세요.',
+      variant: 'destructive',
+    });
+  }
+};

--- a/app/(main)/(home)/history/_components/HistoryPanel.tsx
+++ b/app/(main)/(home)/history/_components/HistoryPanel.tsx
@@ -23,7 +23,7 @@ const HistoryPanel = (history: YoutubeInfo) => {
         height={64}
         className='h-16 w-28 rounded-lg object-cover'
       />
-      <div className='max-w-40 mobile:max-w-32'>
+      <div className='max-w-[166px] mobile:max-w-32'>
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger className='w-full'>

--- a/app/(main)/(home)/layout.tsx
+++ b/app/(main)/(home)/layout.tsx
@@ -7,7 +7,7 @@ const background =
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className={cn('flex flex-col gap-8 mobile:px-2', background)}>
+    <div className={cn('flex flex-col gap-8 px-2', background)}>
       <MainHeader />
       {children}
     </div>

--- a/app/(main)/result/_components/ArticleCard.tsx
+++ b/app/(main)/result/_components/ArticleCard.tsx
@@ -4,12 +4,12 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { Article } from '@/lib/types';
+import { RelatedArticle } from '@/lib/types';
 import { dateFormatter } from '@/lib/utils';
 import { Tooltip } from '@radix-ui/react-tooltip';
 import Link from 'next/link';
 
-const ArticleCard = ({ description, pubDate, title, link }: Article) => {
+const ArticleCard = ({ description, pubDate, title, link }: RelatedArticle) => {
   return (
     <Link href={link}>
       <CardComponent className='py-5'>

--- a/app/(main)/result/_components/ArticleCards.tsx
+++ b/app/(main)/result/_components/ArticleCards.tsx
@@ -1,9 +1,9 @@
 import ArticleCard from './ArticleCard';
 import TitleComponent from '@/components/TitleComponent';
-import { RelatedArticles } from '@/lib/types';
+import { RelatedArticle } from '@/lib/types';
 import { FiPaperclip } from 'react-icons/fi';
 
-const ArticleCards = ({ articles }: { articles: RelatedArticles }) => {
+const ArticleCards = ({ articles }: { articles: RelatedArticle[] }) => {
   return (
     <div className='flex flex-col'>
       <div className='mb-[-7px]'>
@@ -15,9 +15,9 @@ const ArticleCards = ({ articles }: { articles: RelatedArticles }) => {
         </TitleComponent>
       </div>
       <div className='z-10 flex flex-col gap-2'>
-        <ArticleCard {...articles.first_news} />
-        <ArticleCard {...articles.second_news} />
-        <ArticleCard {...articles.third_news} />
+        {articles.map((article, index) => (
+          <ArticleCard key={index} {...article} />
+        ))}
       </div>
     </div>
   );

--- a/app/(main)/result/_components/FeedbackCard.tsx
+++ b/app/(main)/result/_components/FeedbackCard.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { useState } from 'react';
 import TitleComponent from '@/components/TitleComponent';
 import { RiQuestionnaireLine } from 'react-icons/ri';
+import { FaRegThumbsDown, FaRegThumbsUp } from 'react-icons/fa';
 
 const FeedbackCard = ({ video_id }: { video_id: string }) => {
   const { toast } = useToast();
@@ -28,7 +29,6 @@ const FeedbackCard = ({ video_id }: { video_id: string }) => {
         <div className='flex justify-around gap-4'>
           <Button
             variant='icon'
-            className='bg-primary text-primary-foreground hover:bg-primary/90'
             onClick={() => {
               toast({
                 title: '감사합니다!',
@@ -36,13 +36,20 @@ const FeedbackCard = ({ video_id }: { video_id: string }) => {
               });
             }}
           >
-            <HiOutlineThumbUp size={22} />네
+            <FaRegThumbsUp
+              size={22}
+              className='absolute left-5 mobile:left-4'
+            />
+            <p className='absolute right-10 mobile:right-8'>네</p>
           </Button>
           <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
               <Button variant='icon'>
-                <HiOutlineThumbDown size={22} />
-                아니요
+                <FaRegThumbsDown
+                  size={22}
+                  className='absolute left-5 mobile:left-4'
+                />
+                <p className='absolute right-6 mobile:right-4'>아니요</p>
               </Button>
             </DialogTrigger>
             <FeedbackDialog setOpen={setOpen} video_id={video_id} />

--- a/app/(main)/result/_components/FeedbackCard.tsx
+++ b/app/(main)/result/_components/FeedbackCard.tsx
@@ -10,7 +10,7 @@ import { useState } from 'react';
 import TitleComponent from '@/components/TitleComponent';
 import { RiQuestionnaireLine } from 'react-icons/ri';
 
-const FeedbackCard = () => {
+const FeedbackCard = ({ video_id }: { video_id: string }) => {
   const { toast } = useToast();
   const [open, setOpen] = useState<boolean>(false);
 
@@ -30,7 +30,6 @@ const FeedbackCard = () => {
             variant='icon'
             className='bg-primary text-primary-foreground hover:bg-primary/90'
             onClick={() => {
-              // TODO: API 연결
               toast({
                 title: '감사합니다!',
                 description: 'Right Paper를 이용해 주셔서 감사합니다.',
@@ -46,7 +45,7 @@ const FeedbackCard = () => {
                 아니요
               </Button>
             </DialogTrigger>
-            <FeedbackDialog setOpen={setOpen} />
+            <FeedbackDialog setOpen={setOpen} video_id={video_id} />
           </Dialog>
         </div>
       </CardComponent>

--- a/app/(main)/result/_components/FeedbackDialog.tsx
+++ b/app/(main)/result/_components/FeedbackDialog.tsx
@@ -11,7 +11,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 const formSchema = z.object({
-  feedback_text: z.string().max(200),
+  feedback_text: z.string().max(200, '200자 이내로 입력해주세요.'),
 });
 
 const FeedbackDialog = ({
@@ -25,11 +25,29 @@ const FeedbackDialog = ({
 
   // TODO: 추후 Flask 서버로부터의 페칭으로 수정
   const fetchData = async (feedback_text: string) => {
-    const res = await fetch('api/feedback', {
-      method: 'POST',
-      body: JSON.stringify({ video_id, feedback_text }),
-    });
-    console.log(await res.json());
+    try {
+      const res = await fetch('api/feedback', {
+        method: 'POST',
+        body: JSON.stringify({ video_id, feedback_text }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      if (!res.ok) {
+        throw new Error('서버에서 오류가 발생했습니다.');
+      }
+      toast({
+        title: '의견 감사합니다!',
+        description: '귀하의 의견이 성공적으로 전달되었습니다.',
+      });
+      setValue('feedback_text', '');
+    } catch (error) {
+      toast({
+        title: '의견 전송 실패',
+        description: '잠시 후 다시 시도해주세요.',
+        variant: 'destructive',
+      });
+    }
   };
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -40,11 +58,6 @@ const FeedbackDialog = ({
 
   const onSubmit = async (data: z.infer<typeof formSchema>) => {
     fetchData(data.feedback_text);
-    toast({
-      title: '의견 감사합니다!',
-      description: '귀하의 의견이 성공적으로 전달되었습니다.',
-    });
-    setValue('feedback_text', '');
     setOpen(false);
   };
 

--- a/app/(main)/result/_components/FeedbackDialog.tsx
+++ b/app/(main)/result/_components/FeedbackDialog.tsx
@@ -10,6 +10,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { fetchFeedback } from '../_utils/fetchFeedback';
 import { feedbackSchema } from '../_utils/feedbackSchema';
+import { useToast } from '@/components/ui/use-toast';
 
 const FeedbackDialog = ({
   setOpen,
@@ -24,8 +25,10 @@ const FeedbackDialog = ({
 
   const { handleSubmit, register, setValue } = form;
 
+  const { toast } = useToast();
+
   const onSubmit = async (data: z.infer<typeof feedbackSchema>) => {
-    fetchFeedback(video_id, data.feedback_text, setValue);
+    fetchFeedback(video_id, data.feedback_text, setValue, toast);
     setOpen(false);
   };
 

--- a/app/(main)/result/_components/FeedbackDialog.tsx
+++ b/app/(main)/result/_components/FeedbackDialog.tsx
@@ -35,12 +35,13 @@ const FeedbackDialog = ({
       });
       if (!res.ok) {
         throw new Error('서버에서 오류가 발생했습니다.');
+      } else {
+        toast({
+          title: '의견 감사합니다!',
+          description: '귀하의 의견이 성공적으로 전달되었습니다.',
+        });
+        setValue('feedback_text', '');
       }
-      toast({
-        title: '의견 감사합니다!',
-        description: '귀하의 의견이 성공적으로 전달되었습니다.',
-      });
-      setValue('feedback_text', '');
     } catch (error) {
       toast({
         title: '의견 전송 실패',

--- a/app/(main)/result/_components/FeedbackDialog.tsx
+++ b/app/(main)/result/_components/FeedbackDialog.tsx
@@ -6,40 +6,71 @@ import {
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/components/ui/use-toast';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
-const FeedbackDialog = ({ setOpen }: { setOpen: (open: boolean) => void }) => {
+const formSchema = z.object({
+  feedback_text: z.string().max(200),
+});
+
+const FeedbackDialog = ({
+  setOpen,
+  video_id,
+}: {
+  setOpen: (open: boolean) => void;
+  video_id: string;
+}) => {
   const { toast } = useToast();
+
+  // TODO: 추후 Flask 서버로부터의 페칭으로 수정
+  const fetchData = async (feedback_text: string) => {
+    const res = await fetch('api/feedback', {
+      method: 'POST',
+      body: JSON.stringify({ video_id, feedback_text }),
+    });
+    console.log(await res.json());
+  };
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+  });
+
+  const { handleSubmit, register, setValue } = form;
+
+  const onSubmit = async (data: z.infer<typeof formSchema>) => {
+    fetchData(data.feedback_text);
+    toast({
+      title: '의견 감사합니다!',
+      description: '귀하의 의견이 성공적으로 전달되었습니다.',
+    });
+    setValue('feedback_text', '');
+    setOpen(false);
+  };
+
   return (
     <DialogContent className='max-w-mobile rounded-xl px-6 py-8 text-xs'>
-      <DialogTitle className='text-2xl font-semibold'>
-        Right Paper에 의견 보내기
-      </DialogTitle>
-      <DialogDescription className='text-xs'>
-        정보가 도움이 되지 않았나요?
-        <br />더 나은 서비스 제공을 위해 귀하의 의견을 듣고 싶습니다.
-      </DialogDescription>
-      <Textarea
-        placeholder='제공된 정보에 대해 불만족스러운 부분이나 개선이 필요한 점이 있다면, 의견을 보내주시기 바랍니다.'
-        className='h-32 text-xs'
-      />
-      <p className='text-gray-400'>
-        저희 웹사이트는 사용자로부터 개인 식별 정보를 수집하지 않습니다.
-        제공해주신 의견은 서비스 개선을 위해 사용됩니다.
-      </p>
-      <Button
-        variant='main'
-        type='submit'
-        onClick={() => {
-          // TODO: API 연결
-          toast({
-            title: '의견 감사합니다!',
-            description: '귀하의 의견이 성공적으로 전달되었습니다.',
-          });
-          setOpen(false);
-        }}
-      >
-        제출하기
-      </Button>
+      <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-4'>
+        <DialogTitle className='text-2xl font-semibold'>
+          Right Paper에 의견 보내기
+        </DialogTitle>
+        <DialogDescription className='text-xs'>
+          정보가 도움이 되지 않았나요?
+          <br />더 나은 서비스 제공을 위해 귀하의 의견을 듣고 싶습니다.
+        </DialogDescription>
+        <Textarea
+          placeholder='제공된 정보에 대해 불만족스러운 부분이나 개선이 필요한 점이 있다면, 의견을 보내주시기 바랍니다.'
+          className='h-32 text-xs'
+          {...register('feedback_text')}
+        />
+        <p className='text-gray-400'>
+          저희 웹사이트는 사용자로부터 개인 식별 정보를 수집하지 않습니다.
+          제공해주신 의견은 서비스 개선을 위해 사용됩니다.
+        </p>
+        <Button variant='main' type='submit'>
+          제출하기
+        </Button>
+      </form>
     </DialogContent>
   );
 };

--- a/app/(main)/result/_components/FeedbackDialog.tsx
+++ b/app/(main)/result/_components/FeedbackDialog.tsx
@@ -5,14 +5,11 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
-import { useToast } from '@/components/ui/use-toast';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
-
-const formSchema = z.object({
-  feedback_text: z.string().max(200, '200자 이내로 입력해주세요.'),
-});
+import { fetchFeedback } from '../_utils/fetchFeedback';
+import { feedbackSchema } from '../_utils/feedbackSchema';
 
 const FeedbackDialog = ({
   setOpen,
@@ -21,44 +18,14 @@ const FeedbackDialog = ({
   setOpen: (open: boolean) => void;
   video_id: string;
 }) => {
-  const { toast } = useToast();
-
-  // TODO: 추후 Flask 서버로부터의 페칭으로 수정
-  const fetchData = async (feedback_text: string) => {
-    try {
-      const res = await fetch('api/feedback', {
-        method: 'POST',
-        body: JSON.stringify({ video_id, feedback_text }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-      if (!res.ok) {
-        throw new Error('서버에서 오류가 발생했습니다.');
-      } else {
-        toast({
-          title: '의견 감사합니다!',
-          description: '귀하의 의견이 성공적으로 전달되었습니다.',
-        });
-        setValue('feedback_text', '');
-      }
-    } catch (error) {
-      toast({
-        title: '의견 전송 실패',
-        description: '잠시 후 다시 시도해주세요.',
-        variant: 'destructive',
-      });
-    }
-  };
-
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const form = useForm<z.infer<typeof feedbackSchema>>({
+    resolver: zodResolver(feedbackSchema),
   });
 
   const { handleSubmit, register, setValue } = form;
 
-  const onSubmit = async (data: z.infer<typeof formSchema>) => {
-    fetchData(data.feedback_text);
+  const onSubmit = async (data: z.infer<typeof feedbackSchema>) => {
+    fetchFeedback(video_id, data.feedback_text, setValue);
     setOpen(false);
   };
 

--- a/app/(main)/result/_utils/feedbackSchema.ts
+++ b/app/(main)/result/_utils/feedbackSchema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const feedbackSchema = z.object({
+  feedback_text: z.string().max(200, '200자 이내로 입력해주세요.'),
+});

--- a/app/(main)/result/_utils/feedbackSchema.ts
+++ b/app/(main)/result/_utils/feedbackSchema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 export const feedbackSchema = z.object({
   feedback_text: z.string().max(200, '200자 이내로 입력해주세요.'),

--- a/app/(main)/result/_utils/fetchFeedback.ts
+++ b/app/(main)/result/_utils/fetchFeedback.ts
@@ -1,0 +1,35 @@
+import { useToast } from '@/components/ui/use-toast';
+import { UseFormSetValue } from 'react-hook-form';
+
+// TODO: 추후 Flask 서버로부터의 페칭으로 수정
+export const fetchFeedback = async (
+  video_id: string,
+  feedback_text: string,
+  setValue: UseFormSetValue<{ feedback_text: string; }>
+) => {
+  const { toast } = useToast();
+  try {
+    const res = await fetch('api/feedback', {
+      method: 'POST',
+      body: JSON.stringify({ video_id, feedback_text }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!res.ok) {
+      throw new Error('서버에서 오류가 발생했습니다.');
+    } else {
+      toast({
+        title: '의견 감사합니다!',
+        description: '귀하의 의견이 성공적으로 전달되었습니다.',
+      });
+      setValue('feedback_text', '');
+    }
+  } catch (error) {
+    toast({
+      title: '의견 전송 실패',
+      description: '잠시 후 다시 시도해주세요.',
+      variant: 'destructive',
+    });
+  }
+};

--- a/app/(main)/result/_utils/fetchFeedback.ts
+++ b/app/(main)/result/_utils/fetchFeedback.ts
@@ -5,7 +5,7 @@ import { UseFormSetValue } from 'react-hook-form';
 export const fetchFeedback = async (
   video_id: string,
   feedback_text: string,
-  setValue: UseFormSetValue<{ feedback_text: string; }>
+  setValue: UseFormSetValue<{ feedback_text: string }>
 ) => {
   const { toast } = useToast();
   try {

--- a/app/(main)/result/_utils/fetchFeedback.ts
+++ b/app/(main)/result/_utils/fetchFeedback.ts
@@ -1,13 +1,12 @@
-import { useToast } from '@/components/ui/use-toast';
 import { UseFormSetValue } from 'react-hook-form';
 
 // TODO: 추후 Flask 서버로부터의 페칭으로 수정
 export const fetchFeedback = async (
   video_id: string,
   feedback_text: string,
-  setValue: UseFormSetValue<{ feedback_text: string }>
+  setValue: UseFormSetValue<{ feedback_text: string }>,
+  toast: any
 ) => {
-  const { toast } = useToast();
   try {
     const res = await fetch('api/feedback', {
       method: 'POST',

--- a/app/(main)/result/page.tsx
+++ b/app/(main)/result/page.tsx
@@ -73,7 +73,7 @@ const Result = ({
         <AccuracyThumbnail youtube_info={youtube_info} />
         <SummaryCard summary={analysis_result.summary} />
         <ArticleCards articles={related_articles} />
-        <FeedbackCard video_id={youtube_info.video_id}/>
+        <FeedbackCard video_id={youtube_info.video_id} />
       </div>
     </>
   );

--- a/app/(main)/result/page.tsx
+++ b/app/(main)/result/page.tsx
@@ -73,7 +73,7 @@ const Result = ({
         <AccuracyThumbnail youtube_info={youtube_info} />
         <SummaryCard summary={analysis_result.summary} />
         <ArticleCards articles={related_articles} />
-        <FeedbackCard />
+        <FeedbackCard video_id={youtube_info.video_id}/>
       </div>
     </>
   );

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: Request) {
   const { title: video_title, author_name: channel_title } =
     await response.json();
 
-  // fake_possibility is randomly generated between 0.01~0.99
+  // fake_probability is randomly generated between 0.01~0.99
   let fake_probability = Math.random() * 0.98 + 0.01;
 
   return NextResponse.json({
@@ -39,15 +39,15 @@ export async function POST(request: Request) {
       summary:
         '요약: 러시아 군용 전투기가 한국의 독도 주변을 침범한 사건에 대해 미국 국방장관의 발언이 화제를 모으고 있다.\n\n상세 내용:\n- 러시아 군용 전투기가 한국 영공을 침범하여 한국군이 경고 사격을 했고, 이에 대해 일본이 독도 주변에서 사격을 한 듯하게 반응하는 이상한 일이 있었다.\n- 미국의 신임 국방장관은 러시아의 동해에서의 침해 사실을 인정하고 관련하여 발언했으며, 일본은 이를 무시당한 듯한 모습이었다.\n- 독도를 둘러싼 한국-러시아 간 사건에서 미국의 발언은 중립적인 입장을 벗어나 한국을 지지하는 쪽으로 해석될 수 있는데, 이는 현재 일본과의 갈등을 조장할 수 있다고 언급되고 있다.\n- 미국은 독도를 리앙쿠르 록스로 명명하며 중립적 입장을 유지해 왔는데, 이번 발언으로 한국을 응원하는 입장으로 이해될 가능성이 있어 상당히 논란이 되고 있다.',
     },
-    related_articles: {
-      first_news: {
+    related_articles: [
+      {
         description:
           '그러나 그들은 이미 최소 300대의 제트 <b>전투기</b> 외에 더 많은 다른 유형의 <b>군용</b> 비행기를 들여왔다. 그리고... 유엔 측은 진정한 중립국인 스위스와 스웨덴을 지명했지만, 공산주의자들은 이에 <b>러시아</b>의 두 괴뢰국... ',
         link: 'https://www.chosun.com/opinion/column/2024/03/02/2ELVOS3ZSFHQFIMIV6QYPKHGHM/?utm_source=naver&utm_medium=referral&utm_campaign=naver-news',
         pubDate: 'Sat, 02 Mar 2024 02:01:00 +0900',
         title: '국제정치 이론가 이승만의 혜안, “공존은 가능한가?”',
       },
-      second_news: {
+      {
         description:
           '마루타로 불리던 인간 모르모토의 실체가 만주국 항일 게릴라나 간첩, <b>러시아</b> 적군 병사, 중국에서 활동했던... 펑톈에는 <b>전투기</b> 공장이 있었다. 일본군은 기술을 가진 포로들이 그곳에서 일하길 기대했으나 모두가... ',
         link: 'https://view.asiae.co.kr/article/2024012014490321020',
@@ -55,14 +55,14 @@ export async function POST(request: Request) {
         title:
           '&quot;처형당하는 게 당연…인정하기까지 몇 년 걸렸다&quot;(中) [알고보면]',
       },
-      third_news: {
+      {
         description:
           '이에 KAI는 FA-50 추가 수출은 물론 KF-21 <b>전투기</b>, 국산 헬기 수리온, 경공격헬기(LAH) 등에 대한 추가적인 사업... <b>러시아 군용</b>기술의 핵심 공급업체가 비우호적 국가들에 편중되어 있다는 점도 어려움을 가중시키는... ',
         link: 'http://weekly.chosun.com/news/articleView.html?idxno=30252',
         pubDate: 'Tue, 20 Aug 2024 17:01:00 +0900',
         title: 'K방산은 진짜 날개를 달았나?',
       },
-    },
+    ],
     youtube_info: {
       channel_id: 'UCtCp1dJ0QSuFMc8Z4M7g5LQ',
       channel_title,

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -5,5 +5,6 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  return NextResponse.json({ message: '피드백 감사합니다!' });
+  const { video_id, feedback_text } = await request.json();
+  return NextResponse.json({ video_id, feedback_text });
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -19,7 +19,7 @@ const buttonVariants = cva(
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
         main: 'bg-primary text-primary-foreground hover:bg-primary/90 w-full shadow-md',
-        icon: 'bg-gray-200 hover:bg-gray-300/70 shadow-md font-bold text-base gap-2 w-full',
+        icon: 'bg-gray-200 hover:bg-gray-300/80 shadow-md font-bold text-base relative w-32',
         more: 'underline-offset-4 hover:underline',
       },
       size: {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const baseUrl = process.env.NEXT_PUBLIC_BASEURL

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,1 +1,1 @@
-export const baseUrl = process.env.NEXT_PUBLIC_BASEURL
+export const baseUrl = process.env.NEXT_PUBLIC_BASEURL;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,17 +4,11 @@ export enum Loading {
   done,
 }
 
-export interface Article {
+export interface RelatedArticle {
   description: string;
   link: string;
   pubDate: string;
   title: string;
-}
-
-export interface RelatedArticles {
-  first_news: Article;
-  second_news: Article;
-  third_news: Article;
 }
 
 export interface YoutubeInfo {
@@ -31,7 +25,7 @@ export interface AnalysisResult {
 
 export interface ResultData {
   analysis_result: AnalysisResult;
-  related_articles: RelatedArticles;
+  related_articles: RelatedArticle[];
   youtube_info: YoutubeInfo;
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,7 @@ const config = {
   prefix: '',
   theme: {
     screens: {
-      mobile: { max: '384px' },
+      mobile: { max: '430px' },
     },
     container: {
       center: true,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,7 @@ const config = {
   prefix: '',
   theme: {
     screens: {
-      mobile: { max: '430px' },
+      mobile: { max: '384px' },
     },
     container: {
       center: true,
@@ -67,7 +67,7 @@ const config = {
         button: '10px',
       },
       maxWidth: {
-        mobile: '384px',
+        mobile: '430px',
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## 1. 데이터 페칭 에러 핸들링
### analyze

https://github.com/user-attachments/assets/a61c2ec9-1255-4b3b-b228-3831d41b0eaf

### feedback

https://github.com/user-attachments/assets/af942ea9-4ce9-41b2-a7b3-c466a93e29ec

## 2. 로직 분리
데이터 페칭하는 컴포넌트에 코드가 길어져서
zod schema와 fetch 함수를 _utils 폴더로 옮겼습니다

## 3. mobile width 변경
```
maxWidth: {
        mobile: '430px',
      },
```
maxWidth만 430px로 변경했습니다. 
mobile은 여전히 384px로 사용 가능합니다!

레이아웃 기준을 430px로 잡고 소형 모바일 기기 반응형 디자인을 위해 기존처럼 mobile 사용하시면 될 것 같습니다!

## 4. Feedback Card 디자인 변경
### 기존
![image](https://github.com/user-attachments/assets/b649a792-a534-4c22-b5d2-6880d6e73331)
### 변경 후
![image](https://github.com/user-attachments/assets/dbe07ac6-8a57-49f1-8652-52525c8f7bdc)

## 5. History Card 및 Panel 변경
소소하게 mobile 기준 width만 조정했습니다

## 6.  RelatedArticle 스키마 재변경
first_news ... 에서 다시 배열 형태로 수정했습니다.

Closes #52 
Closes #53 
Closes #54 
